### PR TITLE
Replace deprecated gz_frame_id with frame_id in SDF files

### DIFF
--- a/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle.sdf.xacro
@@ -50,7 +50,7 @@
           <always_on>true</always_on>
           <update_rate>200</update_rate>
           <topic>$(arg namespace)/imu</topic>
-          <gz_frame_id>imu_link</gz_frame_id>
+          <frame_id>imu_link</frame_id>
           <imu>
             <angular_velocity>
               <x>
@@ -139,7 +139,7 @@
           <pose>-0.064 0 0.15 0 0 0</pose>
           <update_rate>5</update_rate>
           <topic>$(arg namespace)/scan</topic>
-          <gz_frame_id>base_scan</gz_frame_id>
+          <frame_id>base_scan</frame_id>
           <ray>
             <scan>
               <horizontal>
@@ -379,7 +379,7 @@
           <always_on>1</always_on>
           <update_rate>5</update_rate>
           <pose>0.064 -0.047 0.107 0 0 0</pose>
-          <gz_frame_id>camera_depth_frame</gz_frame_id>
+          <frame_id>camera_depth_frame</frame_id>
           <camera name="realsense_depth_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>

--- a/nav2_minimal_tb3_sim/urdf/gz_waffle_gps.sdf.xacro
+++ b/nav2_minimal_tb3_sim/urdf/gz_waffle_gps.sdf.xacro
@@ -50,7 +50,7 @@
           <always_on>true</always_on>
           <update_rate>200</update_rate>
           <topic>$(arg namespace)/imu/data</topic>
-          <gz_frame_id>imu_link</gz_frame_id>
+          <frame_id>imu_link</frame_id>
           <imu>
             <angular_velocity>
               <x>
@@ -101,7 +101,7 @@
           <always_on>true</always_on>
           <update_rate>1</update_rate>
           <topic>$(arg namespace)/gps/fix</topic>
-          <gz_frame_id>gps_link</gz_frame_id>
+          <frame_id>gps_link</frame_id>
           <navsat>
             <position_sensing>
               <horizontal>
@@ -166,7 +166,7 @@
           <pose>-0.064 0 0.15 0 0 0</pose>
           <update_rate>5</update_rate>
           <topic>$(arg namespace)/scan</topic>
-          <gz_frame_id>base_scan</gz_frame_id>
+          <frame_id>base_scan</frame_id>
           <ray>
             <scan>
               <horizontal>
@@ -428,7 +428,7 @@
           <always_on>1</always_on>
           <update_rate>5</update_rate>
           <pose>0.064 -0.047 0.107 0 0 0</pose>
-          <gz_frame_id>camera_depth_frame</gz_frame_id>
+          <frame_id>camera_depth_frame</frame_id>
           <camera name="realsense_depth_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>

--- a/nav2_minimal_tb4_description/urdf/icreate/common_properties.urdf.xacro
+++ b/nav2_minimal_tb4_description/urdf/icreate/common_properties.urdf.xacro
@@ -55,7 +55,7 @@
       <update_rate>${update_rate}</update_rate>
       <visualize>${visualize}</visualize>
       <always_on>true</always_on>
-      <gz_frame_id>${sensor_name}_link</gz_frame_id>
+      <frame_id>${sensor_name}_link</frame_id>
       <topic>scan</topic>
       <lidar>
         <scan>


### PR DESCRIPTION
## Summary

This PR replaces the deprecated `gz_frame_id` tag with `frame_id` in the SDF sensor definitions.

`gz_frame_id` has been deprecated in favor of `frame_id` in gz-sensors. Using the deprecated tag produces warnings such as:

```text
Warning [Utils.cc:132] ... XML Element[gz_frame_id] ... not defined in SDF.
```

This change removes those warnings while preserving the existing behavior.

Related:

* https://github.com/gazebosim/gz-sensors/pull/444
